### PR TITLE
Documentation and some restructuring

### DIFF
--- a/ansa.go
+++ b/ansa.go
@@ -1,54 +1,62 @@
 package ansa
 
+import (
+	"fmt"
+)
+
+// GetChannelByTopic returns the channel corresponding to the specified topic, or error when it could not be found.
 func GetChannelByTopic(topic string) (Channel, error) {
-	var ChannelErr Channel
 	rss, err := getDecodedTopic(topic)
 	if err != nil {
-		return ChannelErr, err
+		return Channel{}, err
 	}
+
 	return rss.Channel, nil
 }
 
+// GetFeedsByTopic returns the feed list corresponding to the specified topic, or error when it could not be found.
 func GetFeedsByTopic(topic string) ([]Feed, error) {
-	var FeedErr []Feed
-	var err error
 	rss, err := GetChannelByTopic(topic)
 	if err != nil {
-		return FeedErr, nil
+		return nil, err
 	}
+
 	return rss.Feeds, err
 }
 
+// GetTopicList returns the topic list.
 func GetTopicList() []string {
 	return TOPIC_LIST
 }
 
+// GetFeedByGuid returns the feed given the specified guid and topic, or error when it could not be found.
 func GetFeedByGuid(guid string, topic string) (Feed, error) {
-	var FeedErr Feed
 	feeds, err := GetFeedsByTopic(topic)
+	if err != nil {
+		return Feed{}, err
+	}
 
 	for _, feed := range feeds {
 		if feed.Guid == guid {
 			return feed, nil
 		}
 	}
-	if err != nil {
-		return FeedErr, err
-	}
-	return FeedErr, nil
+
+	return Feed{}, fmt.Errorf("GUID %s has no matching topic %s", guid, topic)
 }
 
+// GetFeedByTitle returns the feed given the specified title and topic, or error when it could not be found.
 func GetFeedByTitle(title string, topic string) (Feed, error) {
-	var FeedErr Feed
 	feeds, err := GetFeedsByTopic(topic)
+	if err != nil {
+		return Feed{}, err
+	}
 
 	for _, feed := range feeds {
 		if feed.Title == title {
 			return feed, nil
 		}
 	}
-	if err != nil {
-		return FeedErr, err
-	}
-	return FeedErr, nil
+
+	return Feed{}, fmt.Errorf("Title %s has no matching topic %s", title, topic)
 }

--- a/cmd/ansactl/ansa.go
+++ b/cmd/ansactl/ansa.go
@@ -1,17 +1,20 @@
 package main
 
-// import (
-// 	"fmt"
-// 	"github.com/Owanesh/go-ansa"
-// )
+import (
+	"fmt"
 
+	"../.." // for local testing
+	//"github.com/Owanesh/go-ansa"
+)
 
 func main() {
-	// feed, err := ansa.GetFeedByGuid("http://www.ansa.it/sito/notizie/sport/calcio/2018/09/25/lazio-s.-inzaghi-al-derby-pensero-dopo_e4d76035-4489-404a-93e3-eb3fcf34587b.html", ansa.HOMEPAGE)
-	// if err != nil{
-	// 	return
-	// }
-	// fmt.Printf("feed title: %v\n",  feed.Title)
-	// fmt.Printf("feed GUID: %v\n",  feed.Guid)
+	url := "http://www.ansa.it/sito/notizie/sport/calcio/2018/10/27/consiglio-stato-la-serie-b-torna-a-19_47b88159-3664-4281-8922-1904014302ac.html"
+	feed, err := ansa.GetFeedByGuid(url, ansa.HOMEPAGE)
+	if err != nil {
+		fmt.Printf("err: %v", err)
+		return
+	}
 
+	fmt.Printf("feed title: %v\n", feed.Title)
+	fmt.Printf("feed GUID: %v\n", feed.Guid)
 }

--- a/constant.go
+++ b/constant.go
@@ -1,42 +1,45 @@
 package ansa
 
-const BASE_URL string = "http://www.ansa.it/"
+// Channels
+const (
+	BASE_URL              string = "http://www.ansa.it/"
+	HOMEPAGE                     = "Homepage"
+	CRONACA                      = "Cronaca"
+	POLITICA                     = "Politica"
+	WORLD                        = "Mondo"
+	ECONOMY                      = "Economia"
+	SOCCER                       = "Calcio"
+	SPORT                        = "Sport"
+	CINEMA                       = "Cinema"
+	CULTURE                      = "Cultura"
+	TECHONOLOGY                  = "Tecnologia"
+	LASTHOUR                     = "Ultimaora"
+	ENGLISHNEWS                  = "Englishnews"
+	FOTO                         = "Foto"
+	VIDEO                        = "Video"
+	ABRUZZO                      = "Abruzzo"
+	BASILICATA                   = "Basilicata"
+	CALABRIA                     = "Calabria"
+	CAMPANIA                     = "Campania"
+	EMILIA_ROMAGNA               = "Emilia-Romagna"
+	FRIULI_VENEZIA_GIULIA        = "Friuli-Venezia-Giulia"
+	LAZIO                        = "Lazio"
+	LIGURIA                      = "Liguria"
+	LOMBARDIA                    = "Lombardia"
+	MARCHE                       = "Marche"
+	MOLISE                       = "Molise"
+	PIEMONTE                     = "Piemonte"
+	PUGLIA                       = "Puglia"
+	SARDEGNA                     = "Sardegna"
+	SICILIA                      = "Sicilia"
+	TOSCANA                      = "Toscana"
+	TRENTINO_ALTO_ADIGE          = "Trentino-Alto-Adige"
+	UMBRIA                       = "Umbria"
+	VALLE_AOSTA                  = "Valle-Aosta"
+	VENETO                       = "Veneto"
+)
 
-const HOMEPAGE string = "Homepage"
-const CRONACA string = "Cronaca"
-const POLITICA string = "Politica"
-const WORLD string = "Mondo"
-const ECONOMY string = "Economia"
-const SOCCER string = "Calcio"
-const SPORT string = "Sport"
-const CINEMA string = "Cinema"
-const CULTURE string = "Cultura"
-const TECHONOLOGY string = "Tecnologia"
-const LASTHOUR string = "Ultimaora"
-const ENGLISHNEWS string = "Englishnews"
-const FOTO string = "Foto"
-const VIDEO string = "Video"
-const ABRUZZO string = "Abruzzo"
-const BASILICATA string = "Basilicata"
-const CALABRIA string = "Calabria"
-const CAMPANIA string = "Campania"
-const EMILIA_ROMAGNA string = "Emilia-Romagna"
-const FRIULI_VENEZIA_GIULIA string = "Friuli-Venezia-Giulia"
-const LAZIO string = "Lazio"
-const LIGURIA string = "Liguria"
-const LOMBARDIA string = "Lombardia"
-const MARCHE string = "Marche"
-const MOLISE string = "Molise"
-const PIEMONTE string = "Piemonte"
-const PUGLIA string = "Puglia"
-const SARDEGNA string = "Sardegna"
-const SICILIA string = "Sicilia"
-const TOSCANA string = "Toscana"
-const TRENTINO_ALTO_ADIGE string = "Trentino-Alto-Adige"
-const UMBRIA string = "Umbria"
-const VALLE_AOSTA string = "Valle-Aosta"
-const VENETO string = "Veneto"
-
+// TOPIC_LIST contains all topics.
 var TOPIC_LIST = []string{
 	HOMEPAGE,
 	CRONACA,
@@ -71,8 +74,10 @@ var TOPIC_LIST = []string{
 	TRENTINO_ALTO_ADIGE,
 	UMBRIA,
 	VALLE_AOSTA,
-	VENETO}
+	VENETO,
+}
 
+// CHANNELS_URL is a mapping from channel to URL
 var CHANNELS_URL = map[string]string{
 	HOMEPAGE:              BASE_URL + "sito/ansait_rss.xml",
 	CRONACA:               BASE_URL + "sito/notizie/cronaca/cronaca_rss.xml",
@@ -107,4 +112,5 @@ var CHANNELS_URL = map[string]string{
 	TRENTINO_ALTO_ADIGE:   BASE_URL + "trentino/notizie/trentino_rss.xml",
 	UMBRIA:                BASE_URL + "umbria/notizie/umbria_rss.xml",
 	VALLE_AOSTA:           BASE_URL + "valledaosta/notizie/valledaosta_rss.xml",
-	VENETO:                BASE_URL + "veneto/notizie/veneto_rss.xml"}
+	VENETO:                BASE_URL + "veneto/notizie/veneto_rss.xml",
+}

--- a/controller.go
+++ b/controller.go
@@ -2,49 +2,48 @@ package ansa
 
 import (
 	"encoding/xml"
-	"errors"
+	"fmt"
 	"net/http"
 )
 
 func isValidTopic(topic string) (bool, error) {
-	check := CHANNELS_URL[topic]
-	if check != "" {
-		return true, nil
-	} else {
-		return false, errors.New("Invalid topic \"" + topic + "\"")
+	if topic, ok := CHANNELS_URL[topic]; !ok {
+		return false, fmt.Errorf("Invalid topic: %s", topic)
 	}
+
+	return true, nil
 }
 
 func getChannelLinkByTopic(topic string) (string, error) {
-	valid, err := isValidTopic(topic)
-	if err != nil && !valid {
+	if _, err := isValidTopic(topic); err != nil {
 		return "", err
-	} else {
-		return CHANNELS_URL[topic], nil
 	}
+
+	return CHANNELS_URL[topic], nil
 }
 
 func getXmlDecodedByLink(link string) (RSS, error) {
-	var RSSerr RSS
 	resp, err := http.Get(link)
 	if err != nil {
-		return RSSerr, nil
+		return RSS{}, err
 	}
 	defer resp.Body.Close()
-	rss := RSS{}
+
+	var rss RSS
 	decoder := xml.NewDecoder(resp.Body)
 	err = decoder.Decode(&rss)
 	if err != nil {
 		return rss, err
 	}
+
 	return rss, nil
 }
 
 func getDecodedTopic(topic string) (RSS, error) {
-	var RSSerr RSS
 	link, err := getChannelLinkByTopic(topic)
-	if link != "" {
-		return getXmlDecodedByLink(link)
+	if err != nil {
+		return RSS{}, err
 	}
-	return RSSerr, err
+
+	return getXmlDecodedByLink(link)
 }

--- a/data.go
+++ b/data.go
@@ -1,5 +1,6 @@
 package ansa
 
+// Feed contains information about the RSS feed
 type Feed struct {
 	Title       string `xml:"title"`
 	Link        string `xml:"link"`
@@ -8,6 +9,7 @@ type Feed struct {
 	PubDate     string `xml:"pubDate"`
 }
 
+// Channel contains information about the channel. It contains zero or more feeds.
 type Channel struct {
 	Title       string `xml:"title"`
 	Link        string `xml:"link"`
@@ -16,6 +18,7 @@ type Channel struct {
 	Feeds       []Feed `xml:"item"`
 }
 
+// RSS contains the Channel.
 type RSS struct {
 	Channel Channel `xml:"channel"`
 }


### PR DESCRIPTION
Hi Owanesh,

I've taken the liberty to review your code and make some changes to it.

One of the commits only contains changes by `go fmt`. Golang code is typically formatted using this command. It is a good idea to configure this as `pre-commit` hook in your local repositories. See [go fmt your code](https://blog.golang.org/go-fmt-your-code) for more information.

The other commit contains _a bit_ of documentation in the way `go doc` expects this. Refer to [Godoc: documenting Go code](https://blog.golang.org/godoc-documenting-go-code) for more information. Functions, constants, etc. that can be accessed from _outside_ the package should get a comment stating what it does.

The other commit also contains some internal restructuring. I've changed a couple of constructions you've used (example):
```diff
-func getChannelLinkByTopic(topic string) (string,error){
-       valid, err := isValidTopic(topic)
-       if err != nil && !valid {
-                       return "", err
-       }else{
-               return CHANNELS_URL[topic], nil
+func getChannelLinkByTopic(topic string) (string, error) {
+       if _, err := isValidTopic(topic); err != nil {
+               return "", err
        }
+
+       return CHANNELS_URL[topic], nil
 }
```
It is perfectly valid to use an assignment in an `if` statement in Go. We can disregard the "main" result from a function by specifying `_` (compare: `valid, err := isValidTopic(topic)` vs. `_, err := isValidTopic(topic)`). This shorter form has better readability and we can omit the `else` statement

Another example, we can use an empty struct as return value:
```diff
 func getXmlDecodedByLink(link string) (RSS, error) {
-       var RSSerr RSS
        resp, err := http.Get(link)
        if err != nil {
-               return RSSerr, nil
+               return RSS{}, err
        }
        defer resp.Body.Close()
-       rss := RSS{}
+
+       var rss RSS
        decoder := xml.NewDecoder(resp.Body)
        err = decoder.Decode(&rss)
        if err != nil {
                return rss, err
        }
+
        return rss, nil
 }
```
In this way, the assignment of `rss` is close to its declaration, and we can see from `return RSS{}, err` that we're returning an empty `RSS` struct _and_ we propagate the error message.

In your `package main`, we can see the error propagating back to the caller:
```
$ ./ansactl 
err: GUID http://www.ansa.it/sito/notizie/sport/calcio/2018/10/27/consiglio-stato-la-serie-b-torna-a-19_47b88159-3664-4281-8922-1904014302ac.html has no matching topic Ultimaora```
```

Fixes: #1 